### PR TITLE
Use enums for supported cloud kinds

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@ You will need to set the instance of `Juju` with the following fields:
 ### Juju struct options
 * Note - While several fields are optional, you must include either `MaasCl` __and__ `MaasCr` __or__ `AwsCl` __and__ `AwsCr`
 
-| Field Name     | Required    | Type            | Description                             |
-| -------------- | ----------- | --------------- | --------------------------------------- |
-| Kind           | __Required__| String          |  must be "aws" or "maas"                |
-| Name           | __Required__| String          |  used to set JUJU_DATA path             |
-| Bundle         | __Required__| String          |  ex "cs:bundle/canonical-kubernetes-193"|
-| p  						 |  Optional   | Parallel        | used for multiple cluster creation      |
-| MaasCl         | Optional    | MaasCloud       | maas cloud details                      |
-| MaasCr         | Optional    | MaasCredentials | maas credential details                 |
-| Aws Cl         | Optional    | AwsCloud        | aws cloud details                       |
-| AwsCr          | Optional    | AwsCredentials  | aws credential details                  |  
+| Field Name     | Required    | Type            | Description                                 |
+| -------------- | ----------- | --------------- | ------------------------------------------- |
+| Kind           | __Required__| String          | must use one of the const: `Maas` or `Aws`  |
+| Name           | __Required__| String          | used to set JUJU_DATA path                  |
+| Bundle         | __Required__| String          | ex "cs:bundle/canonical-kubernetes-193"     |
+| p  						 |  Optional   | Parallel        | used for multiple cluster creation          |
+| MaasCl         | Optional    | MaasCloud       | maas cloud details                          |
+| MaasCr         | Optional    | MaasCredentials | maas credential details                     |
+| Aws Cl         | Optional    | AwsCloud        | aws cloud details                           |
+| AwsCr          | Optional    | AwsCredentials  | aws credential details                      |
 
 ## MaasCl Options
 | Field Name     | Required    | Type            | Description                             |
@@ -69,7 +69,7 @@ import (
 )
 
 var testRun = gogo.Juju{
-	Kind:   "maas",
+	Kind:   gogo.Maas,
 	Name:   "test-cluster",
 	Bundle: "cs:bundle/kubernetes-core-306",
 	MaasCl: myMaasCloud,
@@ -107,7 +107,7 @@ import (
 )
 
 var testRun = gogo.Juju{
-	Kind:   "aws",
+	Kind:   gogo.Aws,
 	Name:   "test-cluster",
 	Bundle: "cs:bundle/kubernetes-core-306",
 	AwsCr:  myAWScreds,

--- a/gogo.go
+++ b/gogo.go
@@ -16,11 +16,11 @@ func (j *Juju) Spinup() {
 	controller := ""
 	user := ""
 	tmp := "JUJU_DATA=/tmp/" + j.Name
-	if j.Kind == "aws" {
+	if j.Kind == Aws {
 		j.SetAWSCreds()
 		controller = j.AwsCl.Region
 		user = j.AwsCr.Username
-	} else if j.Kind == "maas" {
+	} else if j.Kind == Maas {
 		j.SetMAASCloud()
 		j.SetMAASCreds()
 		controller = j.MaasCl.Type
@@ -100,9 +100,9 @@ func (j *Juju) GetKubeConfig() {
 // DestroyCluster will kill off one cluster
 func (j *Juju) DestroyCluster() {
 	controller := ""
-	if j.Kind == "aws" {
+	if j.Kind == Aws {
 		controller = j.AwsCl.Region
-	} else if j.Kind == "maas" {
+	} else if j.Kind == Maas {
 		controller = j.MaasCl.Type
 	}
 	controller = strings.Replace(controller, "/", "-", -1)

--- a/structs.go
+++ b/structs.go
@@ -2,9 +2,18 @@ package gogo
 
 import "sync"
 
+// CloudKind is the kind of cloud, eg. aws, maas, etc.
+type CloudKind string
+
+// Supported Cloud Kinds
+const (
+	Aws  CloudKind = "aws"
+	Maas CloudKind = "maas"
+)
+
 // Juju defines the cluster name, which bundle to use, and the manifest for credentials and cloud
 type Juju struct {
-	Kind   string // should be "maas" or "aws" - will be used to figure out which creds and cloud to set
+	Kind   CloudKind // should be gogo.Aws or gogo.Maas - will be used to figure out which creds and cloud to set
 	Name   string
 	Bundle string // ex "cs:bundle/canonical-kubernetes-193"
 	p      Parallel


### PR DESCRIPTION
Since there will always be a limited number of clouds supported, use an
enum to make it clearer what options are available.