### PR TITLE
Make GetKubeConfig return the config file contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ You will need to set the instance of `Juju` with the following fields:
 - `Spinup()` - will spinup cluster from specified creds/cloud/bundle
 - `DisplayStatus()` - will display results of running juju status
 - `ClusterReady()` - will return boolean corresponding to readiness of cluster
-- `GetKubeConfig()` - will print out kubeconfig to stdout
+- `GetKubeConfig()` - return the contents of the kubeconfig file
 - `DestroyCluster()` - will tear down juju controller and associated cluster
 
 
@@ -65,6 +65,8 @@ You will need to set the instance of `Juju` with the following fields:
 package main
 
 import (
+	"fmt"
+
 	"github.com/dstorck/gogo"
 )
 
@@ -93,7 +95,8 @@ func main() {
   testRun.Spinup()
   testRun.DisplayStatus()
   testRun.ClusterReady()
-  testRun.GetKubeConfig()
+  config,_ := testRun.GetKubeConfig()
+	fmt.Println(string(config))
   testRun.DestroyCluster()
 }
 ```

--- a/gogo.go
+++ b/gogo.go
@@ -88,13 +88,16 @@ func (j *Juju) ClusterReady() bool {
 	return true
 }
 
-// GetKubeConfig will cat out kubernetes config to stdout
-func (j *Juju) GetKubeConfig() {
+// GetKubeConfig returns the kubeconfig file contents
+func (j *Juju) GetKubeConfig() ([]byte, error) {
 	tmp := "JUJU_DATA=/tmp/" + j.Name
 	cmd := exec.Command("juju", "ssh", "kubernetes-master/0", "cat", "config")
 	cmd.Env = append(os.Environ(), tmp)
 	out, err := cmd.CombinedOutput()
-	commandResult(out, err, "get kube config")
+	if err != nil {
+		return []byte{}, fmt.Errorf("GetKubeConfig failed: %s", err)
+	}
+	return out, nil
 }
 
 // DestroyCluster will kill off one cluster


### PR DESCRIPTION
As a library function, this needs to return the contents rather than
printing it out.

Fixes #7