### PR TITLE
Change DisplayStatus to GetStatus and return the status as a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ gogo.JujuDataPrefix = "/data"
 - `SetMAASCreds()` sets maas credentials for use with juju
 - `SetMAASCloud()` - sets maas cloud information for use with juju
 - `Spinup()` - will spinup cluster from specified creds/cloud/bundle
-- `DisplayStatus()` - will display results of running juju status
+- `GetStatus()` - will return results of running juju status
 - `ClusterReady()` - will return boolean corresponding to readiness of cluster
 - `GetKubeConfig()` - return the contents of the kubeconfig file
 - `DestroyCluster()` - will tear down juju controller and associated cluster
@@ -104,7 +104,8 @@ func main() {
   testRun.SetMAASCreds()
   testRun.SetMAASCloud()
   testRun.Spinup()
-  testRun.DisplayStatus()
+  status, _ := testRun.GetStatus()
+	fmt.Println(status)
   testRun.ClusterReady()
   config,_ := testRun.GetKubeConfig()
 	fmt.Println(string(config))
@@ -141,7 +142,7 @@ var myAWScloud = gogo.AWSCloud{
 // currently available commands, not meant to be run all at once
 func main() {
   // testRun.SetAWSCreds()
-  // testRun.DisplayStatus()
+  // testRun.GetStatus()
   // testRun.Spinup()
   // testRun.ClusterReady()
   // testRun.GetKubeConfig()

--- a/gogo.go
+++ b/gogo.go
@@ -76,17 +76,17 @@ func (j *Juju) Spinup() error {
 	return nil
 }
 
-// DisplayStatus will ask juju for status
-func (j *Juju) DisplayStatus() error {
+// GetStatus return juju status
+func (j *Juju) GetStatus() (string, error) {
 	tmp := "JUJU_DATA=" + JujuDataPrefix + j.Name
 	cmd := exec.Command("juju", "status")
 	cmd.Env = append(os.Environ(), tmp)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("DisplayStatus error: %s", err)
+		return "", fmt.Errorf("GetStatus error: %s", err)
 	}
 	log.Debug(string(out))
-	return nil
+	return string(out), nil
 }
 
 // ClusterReady will check status and return true if cluster is running


### PR DESCRIPTION
As a library function, we want returned data instead of having it go to
stdout. Rename the function DisplayStatus to GetStatus and have it
return the status as a string.

Fixes #8