### PR TITLE
Make juju data path prefix configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ Currently can bring up kubernetes cluster in CNCT maas lab or on aws.
 
 You will need to set the instance of `Juju` with the following fields:
 
+### JujuDataPrefix variable
+In order to run the juju cli in discrete environments, a different JUJU_DATA path is set per 
+Juju.Name. This path prefix defaults to `/tmp` and will result in the loss of the juju cli
+state as /tmp is ephemeral. 
+
+Set this variable to a path with persistant storage:
+```
+import (
+    "github.com/dstorck/gogo"
+)
+
+gogo.JujuDataPrefix = "/data"
+```
+
 ### Juju struct options
 * Note - While several fields are optional, you must include either `MaasCl` __and__ `MaasCr` __or__ `AwsCl` __and__ `AwsCr`
 

--- a/awsCreds.go
+++ b/awsCreds.go
@@ -57,7 +57,7 @@ func CreateAWSCredsYaml(username string, accessKey string, secretKey string) (st
 
 // SetAWSCreds will grab and credential information and set it
 func (j *Juju) SetAWSCreds() {
-	tmp := "JUJU_DATA=/tmp/" + j.Name
+	tmp := "JUJU_DATA=" + JujuDataPrefix + j.Name
 
 	creds, err := CreateAWSCredsYaml(j.AwsCr.Username, j.AwsCr.AccessKey, j.AwsCr.SecretKey)
 	if err != nil {

--- a/gogo.go
+++ b/gogo.go
@@ -11,11 +11,15 @@ import (
 
 var jStats jujuStatus
 
+// JujuDataPrefix is the path prefix used for the JUJU_DATA environment variable
+// this path will store required juju state and should be persistent
+var JujuDataPrefix = "/tmp/"
+
 // Spinup will create one cluster
 func (j *Juju) Spinup() {
 	controller := ""
 	user := ""
-	tmp := "JUJU_DATA=/tmp/" + j.Name
+	tmp := "JUJU_DATA=" + JujuDataPrefix + j.Name
 	if j.Kind == Aws {
 		j.SetAWSCreds()
 		controller = j.AwsCl.Region
@@ -49,7 +53,7 @@ func (j *Juju) Spinup() {
 
 // DisplayStatus will ask juju for status
 func (j *Juju) DisplayStatus() {
-	tmp := "JUJU_DATA=/tmp/" + j.Name
+	tmp := "JUJU_DATA=" + JujuDataPrefix + j.Name
 	cmd := exec.Command("juju", "status")
 	cmd.Env = append(os.Environ(), tmp)
 	out, err := cmd.CombinedOutput()
@@ -58,7 +62,7 @@ func (j *Juju) DisplayStatus() {
 
 // ClusterReady will check status and return true if cluster is running
 func (j *Juju) ClusterReady() bool {
-	tmp := "JUJU_DATA=/tmp/" + j.Name
+	tmp := "JUJU_DATA=" + JujuDataPrefix + j.Name
 	cmd := exec.Command("juju", "status", "--format=json")
 	cmd.Env = append(os.Environ(), tmp)
 	out, err := cmd.CombinedOutput()
@@ -90,7 +94,7 @@ func (j *Juju) ClusterReady() bool {
 
 // GetKubeConfig returns the kubeconfig file contents
 func (j *Juju) GetKubeConfig() ([]byte, error) {
-	tmp := "JUJU_DATA=/tmp/" + j.Name
+	tmp := "JUJU_DATA=" + JujuDataPrefix + j.Name
 	cmd := exec.Command("juju", "ssh", "kubernetes-master/0", "cat", "config")
 	cmd.Env = append(os.Environ(), tmp)
 	out, err := cmd.CombinedOutput()
@@ -110,7 +114,7 @@ func (j *Juju) DestroyCluster() {
 	}
 	controller = strings.Replace(controller, "/", "-", -1)
 
-	tmp := "JUJU_DATA=/tmp/" + j.Name
+	tmp := "JUJU_DATA=" + JujuDataPrefix + j.Name
 	cmd := exec.Command("juju", "destroy-controller", "--destroy-all-models", controller, "-y")
 	cmd.Env = append(os.Environ(), tmp)
 	out, err := cmd.CombinedOutput()

--- a/maasCloud.go
+++ b/maasCloud.go
@@ -50,7 +50,7 @@ func CreateMAASCloudYaml(name string, endpoint string) (string, error) {
 
 // SetMAASCloud will run juju add-cloud with maasCloud yaml created above
 func (j *Juju) SetMAASCloud() {
-	tmp := "JUJU_DATA=/tmp/" + j.Name
+	tmp := "JUJU_DATA=" + JujuDataPrefix + j.Name
 
 	cloudInfo, err := CreateMAASCloudYaml(j.MaasCl.Type, j.MaasCl.Endpoint)
 	if err != nil {

--- a/maasCreds.go
+++ b/maasCreds.go
@@ -55,7 +55,7 @@ func CreateMAASCredsYaml(cloudName string, username string, maasOauth string) (s
 
 // SetMAASCreds will pass in maas credentials to juju add-credential
 func (j *Juju) SetMAASCreds() {
-	tmp := "JUJU_DATA=/tmp/" + j.Name
+	tmp := "JUJU_DATA=" + JujuDataPrefix + j.Name
 
 	creds, err := CreateMAASCredsYaml(j.MaasCr.CloudName, j.MaasCr.Username, j.MaasCr.MaasOauth)
 	if err != nil {


### PR DESCRIPTION
Storing juju state in /tmp will not work, long-term. This change allows
you to set JujuDataPrefix which will allow you to choose a persistant
storage location.