### PR TITLE
Use an interface for the value of jujuControllers.Controllers

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -67,5 +67,5 @@ type applications struct {
 
 // for use with json parsing with DestroyComplete
 type jujuControllers struct {
-	Controllers map[string]string `json:"controllers"`
+	Controllers map[string]interface{} `json:"controllers"`
 }


### PR DESCRIPTION
Since the value of the json controllers key is not a string, nor do we
really care what it is, use an interface to allow the unmarshalling of
the map. All we care about is the length of `Controllers` anyway.